### PR TITLE
Update GitHub Actions to use latest cache and upload artifact actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
@@ -76,7 +76,7 @@ jobs:
         python -m build --wheel
 
     - name: Upload wheel artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-gen-wheel
         path: dist/*.whl 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -28,7 +28,7 @@ jobs:
         python -m pytest tests/ --benchmark-only --benchmark-skip --benchmark-min-rounds=100
 
     - name: Upload benchmark results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: benchmark-results
         path: .benchmarks/ 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,7 +34,7 @@ jobs:
         safety check --json --output safety-report.json || true
 
     - name: Upload security reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: security-reports
         path: |


### PR DESCRIPTION
- Upgraded actions/cache from v3 to v4 for improved dependency caching.
- Upgraded actions/upload-artifact from v3 to v4 for better artifact management.